### PR TITLE
Improve pytest import reliability and add autograd backward tests

### DIFF
--- a/pydynet/__init__.py
+++ b/pydynet/__init__.py
@@ -1,5 +1,5 @@
 from .core import (Tensor, add, sub, mul, div, pow, matmul, abs, sum, mean,
-                   min, max, min, argmax, argmin, maximum, minimum, exp, log,
+                   min, max, argmax, argmin, maximum, minimum, exp, log,
                    sign, reshape, transpose, swapaxes, concat, sigmoid, tanh,
                    sqrt, square, vsplit, hsplit, dsplit, split, unsqueeze,
                    squeeze)

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -1,9 +1,73 @@
-import sys, pytest, random
-import numpy as np
+import random
+import sys
+from pathlib import Path
 
-sys.path.append('../pydynet')
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pydynet as pdn
 
 np.random.seed(0)
 random.seed(0)
 
-type_list = [np.float16, np.float32, np.float64]
+
+def _assert_allclose(actual, expected, atol=1e-6, rtol=1e-6):
+    assert np.allclose(actual, expected, atol=atol, rtol=rtol)
+
+
+def test_backward_scalar_polynomial():
+    x = pdn.Tensor(2.0, requires_grad=True)
+    y = x**2 + 3 * x - 1
+    y.backward()
+    _assert_allclose(x.grad, np.array(7.0))
+
+
+def test_backward_broadcast_add():
+    x_np = np.random.randn(2, 3).astype(np.float64)
+    b_np = np.random.randn(1, 3).astype(np.float64)
+
+    x = pdn.Tensor(x_np, requires_grad=True)
+    b = pdn.Tensor(b_np, requires_grad=True)
+
+    y = (x + b).sum()
+    y.backward()
+
+    _assert_allclose(x.grad, np.ones_like(x_np))
+    _assert_allclose(b.grad, np.full_like(b_np, x_np.shape[0]))
+
+
+def test_backward_matmul_sum():
+    x_np = np.random.randn(2, 3).astype(np.float64)
+    w_np = np.random.randn(3, 4).astype(np.float64)
+
+    x = pdn.Tensor(x_np, requires_grad=True)
+    w = pdn.Tensor(w_np, requires_grad=True)
+
+    y = pdn.matmul(x, w).sum()
+    y.backward()
+
+    expected_x_grad = np.ones((2, 4), dtype=np.float64) @ w_np.T
+    expected_w_grad = x_np.T @ np.ones((2, 4), dtype=np.float64)
+
+    _assert_allclose(x.grad, expected_x_grad)
+    _assert_allclose(w.grad, expected_w_grad)
+
+
+def test_backward_retain_graph_twice_accumulates_grad():
+    x = pdn.Tensor(2.0, requires_grad=True)
+    y = x * x
+
+    y.backward(retain_graph=True)
+    first_grad = np.array(x.grad, copy=True)
+    y.backward()
+
+    _assert_allclose(first_grad, np.array(4.0))
+    _assert_allclose(x.grad, np.array(8.0))
+
+
+def test_backward_on_non_scalar_raises():
+    x = pdn.Tensor(np.array([1.0, 2.0]), requires_grad=True)
+    with pytest.raises(ValueError, match="scalar"):
+        x.backward()

--- a/tests/test_tensor_basic.py
+++ b/tests/test_tensor_basic.py
@@ -1,8 +1,12 @@
-import sys, pytest, random
-import numpy as np
+import random
+import sys
 from itertools import product
+from pathlib import Path
 
-sys.path.append('../pydynet')
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pydynet as pdn
 


### PR DESCRIPTION
### Motivation
- Ensure tests import the local `pydynet` package reliably when run from the repository root by making test import paths robust. 
- Increase coverage of the autograd engine with focused backward-propagation tests to catch regressions in gradient computation. 
- Clean up an obvious duplicate export in the public `pydynet` API surface.

### Description
- Update `tests/test_tensor_basic.py` to append the project root dynamically via `sys.path.append(str(Path(__file__).resolve().parents[1]))` so tests import `pydynet` reliably. 
- Replace the stub `tests/test_backward.py` with a full suite of backward tests that cover scalar polynomial gradients, broadcasted-add gradient reduction, `matmul + sum` gradients, `retain_graph=True` gradient accumulation, and expecting an error when calling `backward()` on non-scalar tensors. 
- Remove the duplicated `min` re-export from `pydynet/__init__.py` to tidy the public exports. 

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`69 passed in 0.51s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981d71e72c83208ee2cefdab4a7ab4)