### PR TITLE
Add broader pytest coverage for core tensor operators and utilities

### DIFF
--- a/pydynet/__init__.py
+++ b/pydynet/__init__.py
@@ -1,5 +1,5 @@
 from .core import (Tensor, add, sub, mul, div, pow, matmul, abs, sum, mean,
-                   min, max, min, argmax, argmin, maximum, minimum, exp, log,
+                   min, max, argmax, argmin, maximum, minimum, exp, log,
                    sign, reshape, transpose, swapaxes, concat, sigmoid, tanh,
                    sqrt, square, vsplit, hsplit, dsplit, split, unsqueeze,
                    squeeze)

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -1,9 +1,73 @@
-import sys, pytest, random
-import numpy as np
+import random
+import sys
+from pathlib import Path
 
-sys.path.append('../pydynet')
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pydynet as pdn
 
 np.random.seed(0)
 random.seed(0)
 
-type_list = [np.float16, np.float32, np.float64]
+
+def _assert_allclose(actual, expected, atol=1e-6, rtol=1e-6):
+    assert np.allclose(actual, expected, atol=atol, rtol=rtol)
+
+
+def test_backward_scalar_polynomial():
+    x = pdn.Tensor(2.0, requires_grad=True)
+    y = x**2 + 3 * x - 1
+    y.backward()
+    _assert_allclose(x.grad, np.array(7.0))
+
+
+def test_backward_broadcast_add():
+    x_np = np.random.randn(2, 3).astype(np.float64)
+    b_np = np.random.randn(1, 3).astype(np.float64)
+
+    x = pdn.Tensor(x_np, requires_grad=True)
+    b = pdn.Tensor(b_np, requires_grad=True)
+
+    y = (x + b).sum()
+    y.backward()
+
+    _assert_allclose(x.grad, np.ones_like(x_np))
+    _assert_allclose(b.grad, np.full_like(b_np, x_np.shape[0]))
+
+
+def test_backward_matmul_sum():
+    x_np = np.random.randn(2, 3).astype(np.float64)
+    w_np = np.random.randn(3, 4).astype(np.float64)
+
+    x = pdn.Tensor(x_np, requires_grad=True)
+    w = pdn.Tensor(w_np, requires_grad=True)
+
+    y = pdn.matmul(x, w).sum()
+    y.backward()
+
+    expected_x_grad = np.ones((2, 4), dtype=np.float64) @ w_np.T
+    expected_w_grad = x_np.T @ np.ones((2, 4), dtype=np.float64)
+
+    _assert_allclose(x.grad, expected_x_grad)
+    _assert_allclose(w.grad, expected_w_grad)
+
+
+def test_backward_retain_graph_twice_accumulates_grad():
+    x = pdn.Tensor(2.0, requires_grad=True)
+    y = x * x
+
+    y.backward(retain_graph=True)
+    first_grad = np.array(x.grad, copy=True)
+    y.backward()
+
+    _assert_allclose(first_grad, np.array(4.0))
+    _assert_allclose(x.grad, np.array(8.0))
+
+
+def test_backward_on_non_scalar_raises():
+    x = pdn.Tensor(np.array([1.0, 2.0]), requires_grad=True)
+    with pytest.raises(ValueError, match="scalar"):
+        x.backward()

--- a/tests/test_ops_extended.py
+++ b/tests/test_ops_extended.py
@@ -1,0 +1,115 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pydynet as pdn
+
+
+np.random.seed(1)
+
+
+def test_unary_function_forward_matches_numpy():
+    x_np = np.random.uniform(0.5, 2.0, size=(3, 4)).astype(np.float64)
+    x = pdn.Tensor(x_np)
+
+    pairs = [
+        (pdn.abs, np.abs),
+        (pdn.exp, np.exp),
+        (pdn.log, np.log),
+        (pdn.sign, np.sign),
+        (pdn.sigmoid, lambda z: 1.0 / (1.0 + np.exp(-z))),
+        (pdn.tanh, np.tanh),
+        (pdn.sqrt, np.sqrt),
+        (pdn.square, np.square),
+    ]
+
+    for pdn_func, np_func in pairs:
+        pdn_out = pdn_func(x)
+        np_out = np_func(x_np)
+        assert pdn_out.shape == np_out.shape
+        assert np.allclose(pdn_out.data, np_out, atol=1e-6, rtol=1e-6)
+
+
+def test_reduce_function_forward_matches_numpy():
+    x_np = np.random.randn(2, 3, 4).astype(np.float64)
+    x = pdn.Tensor(x_np)
+
+    test_cases = [
+        (lambda t: pdn.sum(t), lambda a: np.sum(a)),
+        (lambda t: pdn.mean(t), lambda a: np.mean(a)),
+        (lambda t: pdn.sum(t, axis=1), lambda a: np.sum(a, axis=1)),
+        (lambda t: pdn.mean(t, axis=(0, 2), keepdims=True),
+         lambda a: np.mean(a, axis=(0, 2), keepdims=True)),
+        (lambda t: pdn.max(t, axis=2), lambda a: np.max(a, axis=2)),
+        (lambda t: pdn.min(t, axis=0), lambda a: np.min(a, axis=0)),
+        (lambda t: pdn.argmax(t, axis=1), lambda a: np.argmax(a, axis=1)),
+        (lambda t: pdn.argmin(t, axis=2), lambda a: np.argmin(a, axis=2)),
+    ]
+
+    for pdn_func, np_func in test_cases:
+        pdn_out = pdn_func(x)
+        np_out = np_func(x_np)
+        assert pdn_out.shape == np_out.shape
+        assert np.allclose(pdn_out.data, np_out)
+
+
+def test_shape_manipulation_matches_numpy():
+    x_np = np.arange(24, dtype=np.float64).reshape(2, 3, 4)
+    x = pdn.Tensor(x_np)
+
+    reshape_out = pdn.reshape(x, (4, 6))
+    assert np.array_equal(reshape_out.data, x_np.reshape(4, 6))
+
+    transpose_out = pdn.transpose(x, (2, 0, 1))
+    assert np.array_equal(transpose_out.data, x_np.transpose(2, 0, 1))
+
+    swapaxes_out = pdn.swapaxes(x, 0, 2)
+    assert np.array_equal(swapaxes_out.data, np.swapaxes(x_np, 0, 2))
+
+    unsqueeze_out = pdn.unsqueeze(x, (0, 2))
+    assert np.array_equal(unsqueeze_out.data, np.expand_dims(np.expand_dims(x_np, 0), 2))
+
+    squeeze_in = pdn.Tensor(np.ones((1, 2, 1, 3), dtype=np.float64))
+    squeeze_out = pdn.squeeze(squeeze_in, axis=(0, 2))
+    assert np.array_equal(squeeze_out.data, np.squeeze(squeeze_in.data, axis=(0, 2)))
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_split_and_concat_roundtrip(axis):
+    x_np = np.random.randn(4, 6, 8).astype(np.float64)
+    x = pdn.Tensor(x_np)
+
+    pieces = pdn.split(x, 2, axis=axis)
+    assert len(pieces) == 2
+
+    merged = pdn.concat(pieces, axis=axis)
+    assert np.allclose(merged.data, x_np)
+
+
+def test_concat_backward_distributes_gradient():
+    a_np = np.random.randn(2, 3).astype(np.float64)
+    b_np = np.random.randn(2, 2).astype(np.float64)
+
+    a = pdn.Tensor(a_np, requires_grad=True)
+    b = pdn.Tensor(b_np, requires_grad=True)
+
+    y = pdn.concat([a, b], axis=1).sum()
+    y.backward()
+
+    assert np.array_equal(a.grad, np.ones_like(a_np))
+    assert np.array_equal(b.grad, np.ones_like(b_np))
+
+
+def test_mean_backward_with_axis_and_keepdims():
+    x_np = np.random.randn(2, 3, 4).astype(np.float64)
+    x = pdn.Tensor(x_np, requires_grad=True)
+
+    y = pdn.mean(x, axis=1, keepdims=True).sum()
+    y.backward()
+
+    expected = np.ones_like(x_np) / x_np.shape[1]
+    assert np.allclose(x.grad, expected)

--- a/tests/test_tensor_basic.py
+++ b/tests/test_tensor_basic.py
@@ -1,8 +1,12 @@
-import sys, pytest, random
-import numpy as np
+import random
+import sys
 from itertools import product
+from pathlib import Path
 
-sys.path.append('../pydynet')
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pydynet as pdn
 


### PR DESCRIPTION
### Motivation

- Increase automated coverage of the core tensor operator set and utility functions to catch regressions in forward and backward behavior. 
- Make test imports reliable when running from the repository root by standardizing test `sys.path` handling. 

### Description

- Add `tests/test_ops_extended.py` with forward-equivalence checks against NumPy for unary ops (`abs`, `exp`, `log`, `sign`, `sigmoid`, `tanh`, `sqrt`, `square`) and reduce ops (`sum`, `mean`, `max`, `min`, `argmax`, `argmin`) including various `axis`/`keepdims` combinations. 
- Add shape/structure tests for `reshape`, `transpose`, `swapaxes`, `unsqueeze`, `squeeze`, plus `split`/`concat` round-trip checks across axes and a backward test verifying `concat` gradient distribution. 
- Expand `tests/test_backward.py` with scalar polynomial gradient, broadcast-add gradient reduction, `matmul + sum` gradients, `retain_graph=True` accumulation behavior, and an assertion that calling `backward()` on non-scalar tensors raises an error; also standardize local import path via `sys.path.append(str(Path(__file__).resolve().parents[1]))`. 
- Standardize test import path handling in `tests/test_tensor_basic.py` using the same `Path`-based `sys.path` append. 
- Tidy public exports in `pydynet/__init__.py` by removing a duplicated `min` re-export. 

### Testing

- Ran the full test suite with `pytest -q` and observed `77 passed, 1 warning`. 
- The single warning is a deprecation notice from `pydynet/core/function.py` about `numpy.core.numeric` and is unrelated to the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981d71e72c83208ee2cefdab4a7ab4)