### PR TITLE
Add Llama fine-tuning support with training utilities, I/O, CLI, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Hi mom saw what happened and said, "Timmy, you need to be more careful. You coul
 Token count: 262, elapsed: 0.87s, 300 tokens/s
 ```
 
+For parameter fine-tuning, run:
+
+```bash
+python -m llm.llama.finetune --text "A short domain sample for adaptation" --steps 30 --lr 1e-4 --trainable lm_head --save llm/llama/data/finetuned_params.npz
+```
+
+Then load the tuned weights for generation:
+
+```bash
+python -m llm.llama.infer --prompt "A short domain sample" --finetuned llm/llama/data/finetuned_params.npz
+```
+
 We also implemented a pure inference version of CLIP, inspired by the NumPy version and dataset available [NPCLIP](https://github.com/99991/NPCLIP). To run it, imigrate `data` folder of `MPCLIP` into `llm/clip` folder and execute: 
 
 ```bash

--- a/llm/llama/finetune.py
+++ b/llm/llama/finetune.py
@@ -1,0 +1,79 @@
+import argparse
+import time
+
+import numpy as np
+
+import pydynet as pdn
+import pydynet.optim as optim
+
+from .io import load_model, save_finetuned_parameters
+from .model import Llama
+from .tokenizer import Tokenizer
+
+
+def build_causal_training_pair(tokenizer: Tokenizer, text: str, max_seq_len: int):
+    token_ids = tokenizer.encode(text, add_bos=True, add_eos=True)
+    if len(token_ids) < 2:
+        raise ValueError("Training text is too short after tokenization.")
+
+    # +1 for shifted labels: [x0..xN-1] -> [x1..xN]
+    token_ids = token_ids[:max_seq_len + 1]
+    if len(token_ids) < 2:
+        raise ValueError("Token sequence must contain at least 2 tokens.")
+
+    input_ids = np.array([token_ids[:-1]], dtype=np.int64)
+    target_ids = np.array([token_ids[1:]], dtype=np.int64)
+    return input_ids, target_ids
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Fine-tune Llama parameters")
+    parser.add_argument("--text", type=str, required=True)
+    parser.add_argument("--steps", type=int, default=30)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--cuda", action='store_true')
+    parser.add_argument("--trainable", type=str, default="lm_head",
+                        help="Comma-separated parameter name prefixes to train")
+    parser.add_argument("--save", type=str, default="llm/llama/data/finetuned_params.npz")
+    args = parser.parse_args()
+
+    dim: int = 288
+    n_layers: int = 6
+    n_heads: int = 6
+    vocab_size: int = 32000
+    max_seq_len: int = 1024
+    max_batch_size: int = 1
+    datatype = np.float32
+
+    tokenizer = Tokenizer("llm/llama/data/tokenizer.model.np")
+    model = load_model(
+        Llama(vocab_size,
+              dim,
+              n_heads,
+              768,
+              max_seq_len,
+              max_batch_size,
+              n_layers,
+              dtype=datatype), "llm/llama/data/stories15M.model.npz")
+
+    if args.cuda and pdn.cuda.is_available():
+        model = model.to('cuda:0')
+
+    prefixes = tuple(p.strip() for p in args.trainable.split(',') if p.strip())
+    trainable_count, frozen_count = model.set_trainable_parameters(prefixes)
+    print(f"Trainable params: {trainable_count}, Frozen params: {frozen_count}")
+
+    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+
+    input_ids, target_ids = build_causal_training_pair(tokenizer, args.text, max_seq_len)
+
+    start = time.time()
+    for step in range(1, args.steps + 1):
+        loss = model.finetune_step(input_ids, target_ids, optimizer)
+        if step == 1 or step % 5 == 0 or step == args.steps:
+            print(f"step={step:04d}, loss={loss:.6f}")
+
+    elapsed = time.time() - start
+    save_finetuned_parameters(model, args.save)
+    print(f"Saved finetuned params to {args.save}")
+    print(f"Elapsed: {elapsed:.2f}s")

--- a/llm/llama/io.py
+++ b/llm/llama/io.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+import pydynet as pdn
+
+from .model import Llama
+
+
+@pdn.no_grad()
+def load_model(llama: Llama, model_path: str) -> Llama:
+    weight = np.load(model_path)
+
+    llama.tok_embedding.weight.data[...] = weight['model.embed_tokens.weight']
+    llama.lm_head.weight.data[...] = weight['lm_head.weight'].T
+
+    for i in range(llama.n_layers):
+        (
+            llama.layers[i].attention.Q.weight.data[...],
+            llama.layers[i].attention.K.weight.data[...],
+            llama.layers[i].attention.V.weight.data[...],
+            llama.layers[i].attention.O.weight.data[...],
+            llama.layers[i].ffn.up.weight.data[...],
+            llama.layers[i].ffn.gate.weight.data[...],
+            llama.layers[i].ffn.down.weight.data[...],
+            llama.layers[i].input_norm.weight.data[...],
+            llama.layers[i].post_attn_norm.weight.data[...],
+        ) = (
+            weight[f'model.layers.{i}.self_attn.q_proj.weight'].T,
+            weight[f'model.layers.{i}.self_attn.k_proj.weight'].T,
+            weight[f'model.layers.{i}.self_attn.v_proj.weight'].T,
+            weight[f'model.layers.{i}.self_attn.o_proj.weight'].T,
+            weight[f'model.layers.{i}.mlp.up_proj.weight'].T,
+            weight[f'model.layers.{i}.mlp.gate_proj.weight'].T,
+            weight[f'model.layers.{i}.mlp.down_proj.weight'].T,
+            weight[f'model.layers.{i}.input_layernorm.weight'],
+            weight[f'model.layers.{i}.post_attention_layernorm.weight'],
+        )
+
+    llama.norm.weight.data[...] = weight['model.norm.weight']
+    return llama
+
+
+@pdn.no_grad()
+def save_finetuned_parameters(model: Llama, output_path: str):
+    params = {}
+    for name, param in model._parameters.items():
+        if param.requires_grad:
+            params[name] = param.numpy()
+    np.savez(output_path, **params)
+
+
+@pdn.no_grad()
+def load_finetuned_parameters(model: Llama, finetuned_path: str):
+    weights = np.load(finetuned_path)
+    for name, param in model._parameters.items():
+        if name in weights:
+            param.data[...] = weights[name]
+    return model

--- a/pydynet/__init__.py
+++ b/pydynet/__init__.py
@@ -1,5 +1,5 @@
 from .core import (Tensor, add, sub, mul, div, pow, matmul, abs, sum, mean,
-                   min, max, min, argmax, argmin, maximum, minimum, exp, log,
+                   min, max, argmax, argmin, maximum, minimum, exp, log,
                    sign, reshape, transpose, swapaxes, concat, sigmoid, tanh,
                    sqrt, square, vsplit, hsplit, dsplit, split, unsqueeze,
                    squeeze)

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -1,9 +1,73 @@
-import sys, pytest, random
-import numpy as np
+import random
+import sys
+from pathlib import Path
 
-sys.path.append('../pydynet')
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pydynet as pdn
 
 np.random.seed(0)
 random.seed(0)
 
-type_list = [np.float16, np.float32, np.float64]
+
+def _assert_allclose(actual, expected, atol=1e-6, rtol=1e-6):
+    assert np.allclose(actual, expected, atol=atol, rtol=rtol)
+
+
+def test_backward_scalar_polynomial():
+    x = pdn.Tensor(2.0, requires_grad=True)
+    y = x**2 + 3 * x - 1
+    y.backward()
+    _assert_allclose(x.grad, np.array(7.0))
+
+
+def test_backward_broadcast_add():
+    x_np = np.random.randn(2, 3).astype(np.float64)
+    b_np = np.random.randn(1, 3).astype(np.float64)
+
+    x = pdn.Tensor(x_np, requires_grad=True)
+    b = pdn.Tensor(b_np, requires_grad=True)
+
+    y = (x + b).sum()
+    y.backward()
+
+    _assert_allclose(x.grad, np.ones_like(x_np))
+    _assert_allclose(b.grad, np.full_like(b_np, x_np.shape[0]))
+
+
+def test_backward_matmul_sum():
+    x_np = np.random.randn(2, 3).astype(np.float64)
+    w_np = np.random.randn(3, 4).astype(np.float64)
+
+    x = pdn.Tensor(x_np, requires_grad=True)
+    w = pdn.Tensor(w_np, requires_grad=True)
+
+    y = pdn.matmul(x, w).sum()
+    y.backward()
+
+    expected_x_grad = np.ones((2, 4), dtype=np.float64) @ w_np.T
+    expected_w_grad = x_np.T @ np.ones((2, 4), dtype=np.float64)
+
+    _assert_allclose(x.grad, expected_x_grad)
+    _assert_allclose(w.grad, expected_w_grad)
+
+
+def test_backward_retain_graph_twice_accumulates_grad():
+    x = pdn.Tensor(2.0, requires_grad=True)
+    y = x * x
+
+    y.backward(retain_graph=True)
+    first_grad = np.array(x.grad, copy=True)
+    y.backward()
+
+    _assert_allclose(first_grad, np.array(4.0))
+    _assert_allclose(x.grad, np.array(8.0))
+
+
+def test_backward_on_non_scalar_raises():
+    x = pdn.Tensor(np.array([1.0, 2.0]), requires_grad=True)
+    with pytest.raises(ValueError, match="scalar"):
+        x.backward()

--- a/tests/test_llama_finetune.py
+++ b/tests/test_llama_finetune.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pydynet.optim as optim
+from llm.llama.model import Llama
+
+
+np.random.seed(7)
+
+
+def _build_tiny_llama(dtype=np.float32):
+    return Llama(
+        vocab_size=16,
+        embed_dim=8,
+        n_heads=2,
+        ffn_dim=16,
+        max_seq_len=8,
+        max_batch_size=1,
+        n_layers=2,
+        dtype=dtype,
+    )
+
+
+def test_forward_logits_shape_for_training():
+    model = _build_tiny_llama()
+    input_ids = np.array([[1, 3, 5, 7]], dtype=np.int64)
+    logits = model.forward_logits(input_ids)
+    assert logits.shape == (1, 4, 16)
+
+
+def test_set_trainable_parameters_freezes_non_selected_prefixes():
+    model = _build_tiny_llama()
+    trainable_count, frozen_count = model.set_trainable_parameters(("lm_head", ))
+
+    assert trainable_count > 0
+    assert frozen_count > 0
+
+    for name, param in model._parameters.items():
+        if name.startswith("lm_head"):
+            assert param.requires_grad
+        else:
+            assert not param.requires_grad
+
+
+def test_finetune_step_updates_selected_parameters_only():
+    model = _build_tiny_llama(dtype=np.float64)
+    model.set_trainable_parameters(("lm_head", ))
+
+    optimizer = optim.Adam(model.parameters(), lr=1e-2)
+    input_ids = np.array([[1, 2, 3, 4]], dtype=np.int64)
+    target_ids = np.array([[2, 3, 4, 5]], dtype=np.int64)
+
+    lm_head_before = model.lm_head.weight.numpy()
+    q_weight_before = model.layers[0].attention.Q.weight.numpy()
+
+    loss = model.finetune_step(input_ids, target_ids, optimizer)
+
+    assert np.isfinite(loss)
+    assert not np.allclose(model.lm_head.weight.numpy(), lm_head_before)
+    assert np.allclose(model.layers[0].attention.Q.weight.numpy(), q_weight_before)

--- a/tests/test_ops_extended.py
+++ b/tests/test_ops_extended.py
@@ -1,0 +1,115 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pydynet as pdn
+
+
+np.random.seed(1)
+
+
+def test_unary_function_forward_matches_numpy():
+    x_np = np.random.uniform(0.5, 2.0, size=(3, 4)).astype(np.float64)
+    x = pdn.Tensor(x_np)
+
+    pairs = [
+        (pdn.abs, np.abs),
+        (pdn.exp, np.exp),
+        (pdn.log, np.log),
+        (pdn.sign, np.sign),
+        (pdn.sigmoid, lambda z: 1.0 / (1.0 + np.exp(-z))),
+        (pdn.tanh, np.tanh),
+        (pdn.sqrt, np.sqrt),
+        (pdn.square, np.square),
+    ]
+
+    for pdn_func, np_func in pairs:
+        pdn_out = pdn_func(x)
+        np_out = np_func(x_np)
+        assert pdn_out.shape == np_out.shape
+        assert np.allclose(pdn_out.data, np_out, atol=1e-6, rtol=1e-6)
+
+
+def test_reduce_function_forward_matches_numpy():
+    x_np = np.random.randn(2, 3, 4).astype(np.float64)
+    x = pdn.Tensor(x_np)
+
+    test_cases = [
+        (lambda t: pdn.sum(t), lambda a: np.sum(a)),
+        (lambda t: pdn.mean(t), lambda a: np.mean(a)),
+        (lambda t: pdn.sum(t, axis=1), lambda a: np.sum(a, axis=1)),
+        (lambda t: pdn.mean(t, axis=(0, 2), keepdims=True),
+         lambda a: np.mean(a, axis=(0, 2), keepdims=True)),
+        (lambda t: pdn.max(t, axis=2), lambda a: np.max(a, axis=2)),
+        (lambda t: pdn.min(t, axis=0), lambda a: np.min(a, axis=0)),
+        (lambda t: pdn.argmax(t, axis=1), lambda a: np.argmax(a, axis=1)),
+        (lambda t: pdn.argmin(t, axis=2), lambda a: np.argmin(a, axis=2)),
+    ]
+
+    for pdn_func, np_func in test_cases:
+        pdn_out = pdn_func(x)
+        np_out = np_func(x_np)
+        assert pdn_out.shape == np_out.shape
+        assert np.allclose(pdn_out.data, np_out)
+
+
+def test_shape_manipulation_matches_numpy():
+    x_np = np.arange(24, dtype=np.float64).reshape(2, 3, 4)
+    x = pdn.Tensor(x_np)
+
+    reshape_out = pdn.reshape(x, (4, 6))
+    assert np.array_equal(reshape_out.data, x_np.reshape(4, 6))
+
+    transpose_out = pdn.transpose(x, (2, 0, 1))
+    assert np.array_equal(transpose_out.data, x_np.transpose(2, 0, 1))
+
+    swapaxes_out = pdn.swapaxes(x, 0, 2)
+    assert np.array_equal(swapaxes_out.data, np.swapaxes(x_np, 0, 2))
+
+    unsqueeze_out = pdn.unsqueeze(x, (0, 2))
+    assert np.array_equal(unsqueeze_out.data, np.expand_dims(np.expand_dims(x_np, 0), 2))
+
+    squeeze_in = pdn.Tensor(np.ones((1, 2, 1, 3), dtype=np.float64))
+    squeeze_out = pdn.squeeze(squeeze_in, axis=(0, 2))
+    assert np.array_equal(squeeze_out.data, np.squeeze(squeeze_in.data, axis=(0, 2)))
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_split_and_concat_roundtrip(axis):
+    x_np = np.random.randn(4, 6, 8).astype(np.float64)
+    x = pdn.Tensor(x_np)
+
+    pieces = pdn.split(x, 2, axis=axis)
+    assert len(pieces) == 2
+
+    merged = pdn.concat(pieces, axis=axis)
+    assert np.allclose(merged.data, x_np)
+
+
+def test_concat_backward_distributes_gradient():
+    a_np = np.random.randn(2, 3).astype(np.float64)
+    b_np = np.random.randn(2, 2).astype(np.float64)
+
+    a = pdn.Tensor(a_np, requires_grad=True)
+    b = pdn.Tensor(b_np, requires_grad=True)
+
+    y = pdn.concat([a, b], axis=1).sum()
+    y.backward()
+
+    assert np.array_equal(a.grad, np.ones_like(a_np))
+    assert np.array_equal(b.grad, np.ones_like(b_np))
+
+
+def test_mean_backward_with_axis_and_keepdims():
+    x_np = np.random.randn(2, 3, 4).astype(np.float64)
+    x = pdn.Tensor(x_np, requires_grad=True)
+
+    y = pdn.mean(x, axis=1, keepdims=True).sum()
+    y.backward()
+
+    expected = np.ones_like(x_np) / x_np.shape[1]
+    assert np.allclose(x.grad, expected)

--- a/tests/test_tensor_basic.py
+++ b/tests/test_tensor_basic.py
@@ -1,8 +1,12 @@
-import sys, pytest, random
-import numpy as np
+import random
+import sys
 from itertools import product
+from pathlib import Path
 
-sys.path.append('../pydynet')
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pydynet as pdn
 


### PR DESCRIPTION
### Motivation
- Enable parameter fine-tuning for the Llama example (currently inference-only) to support lightweight adaptation workflows and provide a simple training CLI and save/load utilities. 
- Provide a minimal API for freezing/unfreezing parameters and running single optimization steps so examples and users can experiment with domain adaptation. 
- Move model checkpoint I/O out of the inference script for reuse between training and inference. 
- Add automated tests to validate the new training-related behavior and keep regressions from being introduced.

### Description
- Extended the `Llama` model with `_forward_hidden`, `forward_logits`, `set_trainable_parameters`, and `finetune_step` to expose full-sequence logits for training, freeze parameters by name-prefix, and run a forward+loss+backward+optimizer step via `finetune_step` (`llm/llama/model.py`).
- Extracted checkpoint and fine-tuned-parameter I/O into `llm/llama/io.py` providing `load_model`, `save_finetuned_parameters`, and `load_finetuned_parameters` so inference and finetuning share the same loading/saving utilities.
- Added a runnable finetuning CLI `llm/llama/finetune.py` which builds causal training pairs from text, selects trainable prefixes, runs optimization steps, and saves tuned parameters to a `.npz` file.
- Updated the inference script `llm/llama/infer.py` to accept a `--finetuned` argument and optionally load tuned weights on top of the base checkpoint before generation.
- Added tests `tests/test_llama_finetune.py` validating `forward_logits` shape, `set_trainable_parameters` freezing behavior, and that `finetune_step` updates only selected parameters; also adjusted/expanded test imports and a few other test files to standardize `sys.path` handling and increase coverage.
- Documented the finetuning and reload workflow in `README.md` with example commands.

### Testing
- Ran the full test suite with `pytest -q`, which executed the new finetuning tests together with the existing suite and resulted in `80 passed, 25 warnings`.
- The test run included the new `tests/test_llama_finetune.py` tests which passed. 
- The test run shows an unrelated NumPy deprecation warning originating from `pydynet/core/function.py` and not from these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981d71e72c83208ee2cefdab4a7ab4)